### PR TITLE
Adjust gender of persons

### DIFF
--- a/CCH Change/CCH017 Adjust author gender/C6+_Change_Gender_of_Authors.cs
+++ b/CCH Change/CCH017 Adjust author gender/C6+_Change_Gender_of_Authors.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Linq;
+using System.ComponentModel;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using System.IO;
+
+using SwissAcademic.Citavi;
+using SwissAcademic.Citavi.Metadata;
+using SwissAcademic.Citavi.Shell;
+using SwissAcademic.Collections;
+
+// Implementation of macro editor is preliminary and experimental.
+// The Citavi object model is subject to change in future version.
+
+public static class CitaviMacro {
+	public static void Main() {
+	
+		if (Program.ProjectShells.Count == 0) return;		// no project open
+		if (IsBackupAvailable() == false) return;			// user wants to backup his/her project first
+		
+		//Get the active project
+		Project activeProject = Program.ActiveProjectShell.Project;
+		
+		//get names and exit if none are present
+		Person[] authors = activeProject.Persons.ToArray();
+		if (!authors.Any()) return;
+		
+		// TODO: maybe there is method that directly gets the folder and/or file?
+		//       If so, can the default list and this list be merged?
+		string path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData));
+		path += @"\Swiss Academic Software\Citavi 6\Settings\Firstnames.txt";
+		
+		if (!File.Exists(path)) {
+			MessageBox.Show(
+				"'" + path + "' doesn't exist. The script will be aborted.", 
+				"Citavi Macro", MessageBoxButtons.OK, MessageBoxIcon.Information);
+			return;
+		}
+		
+		// TODO: check if entries are unique?
+		Dictionary<string, string> namesAndSex = new Dictionary<string, string> ();
+		System.IO.File.ReadAllLines(path)
+				.ForEach(entry => {
+					var nS = entry.Split(new[] {','});
+					string name = nS[0];
+					string sex = nS[1];
+					namesAndSex.Add(name, sex);
+				});
+		
+		int counter = 0;
+		
+		foreach(Person author in authors) {
+			if (author.Sex == SwissAcademic.Sex.Unknown) {
+				string firstName = author.FirstName;
+				if (namesAndSex.ContainsKey(firstName)) {
+					var sex = namesAndSex[firstName];
+					string message = "Set gender of '" + author.FullName + "' to: ";
+					
+					try {
+						switch (sex) {
+							case "M":
+								author.Sex = SwissAcademic.Sex.Male;
+								message += sex;
+								break;
+							case "F":
+								author.Sex = SwissAcademic.Sex.Female;
+								message += sex;
+								break;
+							case "N":
+								author.Sex = SwissAcademic.Sex.Neutral;
+								message +=  sex;
+								break;
+							default:
+								message = "! gender '" + sex + "' is not available in Citavi.";
+								break;
+						}
+					} catch (Exception e) {
+						DebugMacro.WriteLine("An error occurred with '" + author.FullName + "': " + e.Message);
+					}
+					counter++;
+				}
+			}
+		}
+		
+		// Message upon completion
+		string boxMessage = "";
+		if (counter == 1) {
+			boxMessage = "{0} gender of authors has been set.";
+		} else {
+        	boxMessage = "{0} genders of authors have been set.";
+		}
+        boxMessage = string.Format(boxMessage, counter.ToString());
+        MessageBox.Show(boxMessage, "Citavi Macro", MessageBoxButtons.OK, MessageBoxIcon.Information);
+	}
+	
+	// Ask whether backup is available
+	private static bool IsBackupAvailable() {
+		string warning = String.Concat("Important: This macro will make irreversible changes to your project.",
+			"\r\n\r\n", "Make sure you have a current backup of your project before you run this macro.",
+			"\r\n", "If you aren't sure, click Cancel and then, in the main Citavi window, on the File menu, click Create backup.",
+			"\r\n\r\n", "Do you want to continue?"
+		);
+		
+		return (MessageBox.Show(warning, "Citavi", MessageBoxButtons.OKCancel, MessageBoxIcon.Exclamation, MessageBoxDefaultButton.Button2) == DialogResult.OK);
+	}
+}

--- a/CCH Change/CCH017 Adjust author gender/readme.de.md
+++ b/CCH Change/CCH017 Adjust author gender/readme.de.md
@@ -1,0 +1,23 @@
+# Geschlecht von Personen setzen
+
+Sie haben die Vornamen-Datenbank erweitert (siehe im Citavi-Manual [Citavis Vornamen-Datenbank erweitern](https://www1.citavi.com/sub/manual6/de/index.html?extending_the_name_database.html)) und wollen nun in das Geschlecht der Personen in einem bestehenden Projekt gegen die neue Vornamen-Datenbank abgleichen.
+Das Geschlecht wird jedoch nur bei neuen Personen gegen die Vornamen-Datenbank geprüft.
+Es müssten also alle Personen mit unbekannten Geschlecht von Hand gegen die Vornamen-Datenbank prüfen.
+
+## Lösung
+
+Das hier bereitgestellte Makro automatisiert diese Aufgabe.
+Es prüft alle Personen mit unbekannten Geschlecht im aktiven Projekt und passt ggf. das Geschlecht an.
+
+## Download
+
+[für Citavi 6 und neuer](C6+_Change_Gender_of_Authors.cs)
+
+## Anwendung
+
+Folgen Sie der Anleitung in [diesem Artikel](/readme.de.md), um das Makro einzusetzen.
+
+## Autors
+
+- Johannes Franz @Belisarith
+- Stefan Pinnow @Mo-Gul

--- a/CCH Change/CCH017 Adjust author gender/readme.md
+++ b/CCH Change/CCH017 Adjust author gender/readme.md
@@ -1,0 +1,25 @@
+# Set Gender of Persons
+
+[[> Deutsche Version](readme.de.md)]
+
+You have extended the first name database (see the Citavi Manual [Adding to the First Name Database](https://www1.citavi.com/sub/manual6/en/index.html?extending_the_name_database.html)) and now want to check the gender of people in an existing project against the new first name database.
+However, the gender is only checked against the first name database for newly added people.
+So all persons with unknown gender would have to be checked manually against the first name database.
+
+## Solution
+
+The macro provided here automates this task.
+It checks all persons with unknown gender in the active project and adjusts the gender if necessary.
+
+## Download
+
+[for Citavi 6 and newer](C6+_Change_Gender_of_Authors.cs)
+
+## Application
+
+Follow the instructions in [this article](/readme.md) to use the macro.
+
+# Authors
+
+- Johannes Franz @Belisarith
+- Stefan Pinnow @Mo-Gul


### PR DESCRIPTION
When adding names to the `Firstname.txt` these names are only used when new entries are added to a project. Thus, when the `Firstname.txt` file was changed/extended it would be a manual task to compare the new entries to the list of persons. Here the corresponding script/macro.

Open actions:

- [ ] Suggest final folder and its name.
- [ ] Replace the "hard-coded" path to the file with an internal variable? (See `TODO` note in the code)
- [ ] Should the `Firstnames.txt` file be checked for (non-unique) duplicates? (See `TODO` note in the code)